### PR TITLE
Change Patternlab composer project for php twig

### DIFF
--- a/pattern-lab-2/php/twig/Dockerfile
+++ b/pattern-lab-2/php/twig/Dockerfile
@@ -28,7 +28,7 @@ RUN chmod o+w /opt
 USER pl2
 
 # Create a default Pattern Lab project
-RUN composer create-project pattern-lab/edition-mustache-standard \
+RUN composer create-project pattern-lab/edition-twig-standard \
     /opt/pattern-lab
 
 # Make Pattern Lab source files available for modification


### PR DESCRIPTION
In php/twig Dockerfile, `composer create-project` created a `pattern-lab/edition-mustache-standard` project. Now it creates a `pattern-lab/edition-twig-standard` project.